### PR TITLE
porubaCandidates: add head candidates for Poruba

### DIFF
--- a/_candidatelists/radnice.md
+++ b/_candidatelists/radnice.md
@@ -15,13 +15,18 @@ head: # čelo kandidátky (bez leadera) / lidé kteří mají fotku a _people/jm
     profession: informatik - databázový specialista
     description: 
     party: Piráti
+  - uid: andrea.hoffmannova
+    age: 35  
+    profession: vysokoškolská pedagožka
+    description: 
+    party: Piráti
 tail: # zbytek kandidatky
       # jedinná povinná položka je name zbytek můžete vynechat
       # věk se uvádí k poslednímu dni voleb
-  - name:  Mgr. Andrea Hoffmannová, Ph.D.
-    age: 35
-    profession:  vysokoškolská pedagožka
-    party: Piráti
+  - name:  Ing. Petr Kopečný
+    age: # zjistit
+    profession:  automatizační inženýr
+    party: # Piráti - ověřit
  
 
 note: # poznámka pod kanidátku

--- a/_people/andrea-hoffmannova.md
+++ b/_people/andrea-hoffmannova.md
@@ -1,0 +1,29 @@
+---
+uid: andrea.hoffmannova
+name:     Andrea Hoffmannová  	# běžně používáné jméno
+fullname: Mgr. Andrea Hoffmannová, Ph.D.  	# jméno s tituly etc.
+category:                 	# kategorie: rp, praha, vary, hradec, jmk, senat
+  - kandidat 
+img:   # 165 x 220
+description: kandidátka na starostku Ostravy-Poruby            	# kratký popis, max 160 znaků
+mail:
+- andrea.hoffmannova@pirati.cz
+mob:			  
+profiles:
+  github:       
+  facebook: https://www.facebook.com/andrea.hoffmannova.5
+  twitter: 		  
+  flickr:	 
+---
+
+Andrea Hoffmannová je kandidátkou na starostku Ostravy-Poruby.
+
+Celou svou kariéru se věnuje práci s mladými lidmi. Svou profesní dráhu začala jako středoškolská učitelka. Kromě akademického působení na Univerzitě Palackého nyní organizuje workshopy pro učitele a věnuje se vzdělávání dospělých, moderuje ostravské vzdělávací a kulturní akce. Se svými studenty připravila již několik desítek divadelních představení v českém i anglickém jazyce.
+
+Prosazuje zvyšování čtenářské a mediální gramotnosti a inovativní výuku angličtiny se snahou reformovat české školství. 
+
+Přestože přednáší na univerzitách v Evropě a Spojených státech, jejím domovem je Ostrava.
+
+Po Fulbrightově stipendiu v USA dostala nabídku na práci asistentky europoslance, která jí přinesla mnoho zkušeností z nejvyšší politiky, otevřela nové obzory a také potřebu aktivněji zasahovat do politického života naší země.
+
+Věří, že je díky svým pracovním i životním zkušenostem a morální konzistencí schopna prosazovat potřeby občanů Ostravy-Poruby.

--- a/_people/denisa-kucerova.md
+++ b/_people/denisa-kucerova.md
@@ -1,0 +1,21 @@
+---
+uid: denisa.kucerova
+name:     Denisa Kučerová  	# běžně používáné jméno
+fullname: Bc. Denisa Kučerová  	# jméno s tituly etc.
+category:                 	# kategorie: kandidat, pks, zastupitel
+- kandidat 
+img:   # 165 x 220
+description: kandidátka do zastupitelstva Ostravy-Poruby   	# kratký popis, max 160 znaků
+mail:
+# - zjistit
+---
+
+Denisa žije v Ostravě 11. rokem. Je vdaná a má dceru.
+
+Pracuje jako referent pro sport, ale má zkušenosti i ze zaměstnanosti a sociální problematiky.
+
+Pirátská strana je jí velice blízká svým transparentním přístupem a liberální politikou a rovněž přístupem lidí, kteří tvoří tuto stranu
+
+Poruba je její srdeční záležitost a chtěla by, aby se stala nejen místem pro studium a pro život, ale i místem pro zaměstnání. Zajímá se také o celkový rozvoj obvodu v oblasti kulturní, sportovní a udržitelné péče o zeleň.
+
+Považuje za důležité dokončení důležitých staveb jako je rekonstrukce Domu kultury Poklad a Sportovního areálu Poruba (bývalý VOKD).

--- a/_people/jakub-pohl.md
+++ b/_people/jakub-pohl.md
@@ -1,0 +1,21 @@
+---
+uid: jakub.pohl
+name:     Jakub Pohl  	# běžně používáné jméno
+fullname: Jakub Pohl  	# jméno s tituly etc.
+category:                 	# kategorie: kandidat, pks, zastupitel
+- kandidat 
+img:   # 165 x 220
+description: kandidát do zastupitelstva Ostravy-Poruby   	# kratký popis, max 160 znaků
+mail:
+# - zjistit
+---
+
+Narozen v Ostravě, převážnou část života žije v městské části Poruba. Vystudoval divadelní fakultu JAMU v Brně, obor Jevištní technologie.
+
+Pracoval jako osvětlovač i zvukař v Divadle U stolu, Studio Marta, ale i na menších scénách a divadelních projektech u nás i v zahraničí. Dále pracoval jako IT technik, fotograf, grafik a asistent při výuce paraglidingu.
+
+V současné době pracuje v České televizi Ostrava jako technik živých přenosů a jako osoba samostatně výdělečně činná se živí jako kameraman a střihač. 
+
+Je ženatý a hrdý otec dvou synů. Má rád audiovizuální umění, divadlo, literaturu ale i outdoorové aktivity.
+
+Rád by se zasadil o zelenou, čistší a kulturní Porubu.

--- a/_people/jiri-rajnoch.md
+++ b/_people/jiri-rajnoch.md
@@ -1,0 +1,21 @@
+---
+uid: jiri.rajnoch
+name:     Jiří Rajnoch  	# běžně používáné jméno
+fullname: Ing. Jiří Rajnoch  	# jméno s tituly etc.
+category:                 	# kategorie: kandidat, pks, zastupitel
+- kandidat 
+img:   # 165 x 220
+description: kandidát do zastupitelstva Ostravy-Poruby   	# kratký popis, max 160 znaků
+mail:
+# - jiri.rajnoch@pirati.cz - ověřit
+---
+
+Jirka Rajnoch chodil do školky na základní, střední a vysokou školu do Ostravy-Poruby!
+
+Je ostravský a porubský patriot.
+
+Kdyby to šlo tak by v porubě i pracoval, jenže Poruba funguje jako satelitní část Ostravy, která slouží k bydlení, a proto by to chtěl změnit.
+
+Například změnit Černou perlu v místo, kde bude dost práce s přidanou hodnotou.
+
+Razí heslo, které se line tribunama na porubském hokeji. Za Porubu do porubu!

--- a/_people/martin-tomasek.md
+++ b/_people/martin-tomasek.md
@@ -1,0 +1,23 @@
+---
+uid: martin.tomasek
+name:     Martin Tomášek  	# běžně používáné jméno
+fullname: Mgr. Martin Tomášek, Ph.D.  	# jméno s tituly etc.
+category:                 	# kategorie: kandidat, pks, zastupitel
+- kandidat
+img:   # 165 x 220
+description: kandidát do Senátu v obvodu Ostrava-město, kandidát do zastupitelstva Ostravy-Poruby   	# kratký popis, max 160 znaků
+mail:
+# - martin.tomasek@pirati.cz - ověřit
+---
+
+Martin Tomášek se do Poruby přiženil v roce 1991 a považuje ji za ideální místo k životu.
+
+V letech 1992-2001 učil na dnešním Wichterlově gymnáziu, od té doby až dodnes působí na katedře české literatury Ostravské univerzity. Mimo jiné tam připravuje budoucí češtináře, díky čemuž neztratil s Porubou ani profesní kontakt - pravidelně navštěvuje své bývalé pracoviště i Jazykové gymnázium Pavla Tigrida.
+
+Pokládá za důležité využívat výhod Poruby jako univerzitního města, na jehož životě by se měly podílet obě univerzity, Ostravská i Technická. Cílem je kvalitní výukou udržet mladé lidi v Ostravě nebo jim po návratu ze studií nabídnout atraktivní možnosti uplatnění a perspektivu dobrého bydlení.
+
+Rád by v pomohl s vytvořením porubské odnože kulturního a vzdělávacího Centra PANT jako místa pro diskuse se zajímavými lidmi a zdroje nezávislého myšlení.
+
+Je stoupencem moderní, tj. rychlé, pohodlné a cenově dostupné veřejné dopravy, podporuje rozšiřování cyklostezek a alternativní dopravy, lokálních sportovišť a ochranu přírodního bohatství.
+
+V ZDRAVÉM MĚSTĚ ZDRAVÝ (VZ)DUCH!

--- a/_people/pavel-kucera.md
+++ b/_people/pavel-kucera.md
@@ -1,0 +1,19 @@
+---
+uid: pavel.kucera
+name:     Pavel Kučera  	# běžně používáné jméno
+fullname: Mgr. Pavel Kučera  	# jméno s tituly etc.
+category:                 	# kategorie: kandidat, pks, zastupitel
+- kandidat 
+img:   # 165 x 220
+description: kandidát do zastupitelstva Ostravy-Poruby   	# kratký popis, max 160 znaků
+mail:
+# - zjistit
+---
+
+Pavel žije celý svůj život v Porubě, nakonec i dnes jej můžete potkat na procházce s manželkou a dcerkou. S krátkou přestávkou při studiu střední školy zde prožil i svá studentská léta, které zakončil vysokou školou v oboru informačních technologií. Nyní pracuje v Porubě jako programátor.
+
+Pirátská strana byla pro něj jasná volba protože ví že transparentnost a liberální politika je ta správná cesta. 
+
+Jeho cílem je atraktivní život v moderní Porubě, nejen po osobní ale i po profesní stránce. K tomu je ale nutné dokončit stávající dlouhodobé projekty, být partnerem investorům ale i podporovat podnikání, pevnější spolupráci radnice a vysoké školy a jejích studentů.
+
+Zajímá se tak o koncepční rozvoj obvodu, zkvalitnění veřejných prostranství a podporu aktivního života spoluobčanů.

--- a/_people/pavel-sikora.md
+++ b/_people/pavel-sikora.md
@@ -1,0 +1,21 @@
+---
+uid: pavel.sikora
+name:     Pavel Sikora  	# běžně používáné jméno
+fullname: Mgr. Pavel Sikora  	# jméno s tituly etc.
+category:                 	# kategorie: kandidat, pks, zastupitel
+- kandidat 
+img:   # 165 x 220
+description: kandidát do zastupitelstva Ostravy-Poruby   	# kratký popis, max 160 znaků
+mail:
+# - zjistit
+---
+
+Pavel je porubský patriot, v Porubě žije celý život a nehodlá to měnit.
+
+Od absolvování vysoké školy pracuje jako kulturní referent a vedoucí provozu digitálního kina.
+
+Jeho prioritou je mít v Porubě ucelenou kulturní koncepci opírající se o DK Poklad a zachování areálu letního kina.
+
+Mimo kulturní oblast se zabývá také životním prostředím.
+
+Jeho koníčkem je především fotografování industrialu.

--- a/_people/vladan-hyl.md
+++ b/_people/vladan-hyl.md
@@ -1,0 +1,19 @@
+---
+uid: vladan.hyl
+name:     Vladan Hýl  	# běžně používáné jméno
+fullname: Vladan Hýl  	# jméno s tituly etc.
+category:                 	# kategorie: kandidat, pks, zastupitel
+- kandidat 
+img:   # 165 x 220
+description: kandidát do zastupitelstva Ostravy-Poruby   	# kratký popis, max 160 znaků
+mail:
+# - zjistit
+---
+
+Vladan vystudoval herectví na Janáčkově konzervatoři v Ostravě.
+
+Prošel několika firmami a projekty, kde se věnoval mediálním a uměleckým tématům. V současnosti pracuje jako redaktor zpravodajství v celostátním rádiu.
+
+Angažuje se v aktivitách souvisejících s kulturou, médii a veřejným životem. 
+
+Kultura, veřejný prostor, zkušenosti s využitím veřejného prostoru ze Středozemí. 


### PR DESCRIPTION
Vytvořeny chybějící profily top10 kandidátů pro Porubu. Andrea Hoffmannová přidána do kandidátky na radnici.